### PR TITLE
Remove Google Analytics from Kogito Docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,15 +20,6 @@
 <!doctype html>
 <html lang="en" class="pf-m-redhat-font">
   <head>
-    <!-- Google Tag Manager -->
-    <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-PQGMKNW');
-    </script>
-    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1867

[kogito-docs/index.html](https://kie.apache.org/kogito-docs/index.html) uses _**Google Analytics**_ which is not permitted by the ASF Privacy Policy (please see [Issue #1867](https://github.com/apache/incubator-kie-issues/issues/1867) for more details).

Is this the correct source file for [kogito-docs/index.html](https://kie.apache.org/kogito-docs/index.html) , if so, please could you apply this PR and re-generate the site to publish a new version of that page.

Thank You

Niall